### PR TITLE
Add rate independent plasticity and rate switching models

### DIFF
--- a/examples/structural-material-models/kocks-mecking.py
+++ b/examples/structural-material-models/kocks-mecking.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+"""
+    This example tests the Kocks-Mecking flow rule switching model
+    by verifying we can switch from a viscoplastic to a rate independent
+    response as a function of temperature and strain rate.
+"""
+
+import sys
+
+sys.path.append("../..")
+
+import torch
+import numpy as np
+
+import matplotlib.pyplot as plt
+
+from pyoptmat import models, flowrules, experiments, hardening, temperature
+
+torch.set_default_tensor_type(torch.DoubleTensor)
+
+def calculate_yield(strain, stress, offset = 0.2/100.0):
+    """
+    Calculate the yield stress given a strain/stress history
+
+    Args:
+        strain (torch.tensor):      batched strains
+        stress (torch.tensor):      batched stress
+        offset (float, 0.002):      offset strain
+    """
+    E = (stress[1] - stress[0]) / (strain[1] - strain[0])
+
+    vals = E * (strain - offset)
+
+    first = (vals - stress) > 0
+
+    vals, inds = torch.max(first, dim = 0)
+
+    return torch.diag(stress[inds])
+
+if __name__ == "__main__":
+    E = temperature.PolynomialScaling(
+            [-6.82798735e-05, 9.48207244e-02, -1.11026526e+02, 2.21183687e+05])
+    mu = temperature.PolynomialScaling(
+            [-2.60610204e-05, 3.61911162e-02, -4.23765368e+01, 8.44212545e+04])
+    g0 = torch.tensor(0.771)
+    k = torch.tensor(1.38064e-20)
+    b = torch.tensor(2.019e-7)
+    eps0 = torch.tensor(1.0e6)
+
+    A = torch.tensor(-3.35)
+    B = torch.tensor(-3.23)
+    C = torch.tensor(-5.82)
+    
+    n = temperature.KMRateSensitivityScaling(A, mu, b, k)
+    eta = temperature.KMViscosityScaling(A, B, mu, eps0, b, k)
+    s0 = temperature.ShearModulusScaling(torch.exp(C), mu)
+
+    eps0_ri = 1e-10
+    lmbda = 0.99
+
+    R = temperature.ConstantParameter(torch.tensor(100.0))
+    d = temperature.ConstantParameter(torch.tensor(20.0))
+
+    iso_hardening = hardening.VoceIsotropicHardeningModel(R, d)
+    kin_hardening = hardening.NoKinematicHardeningModel()
+
+    rd_flowrule = flowrules.IsoKinViscoplasticity(n, eta, 
+            temperature.ConstantParameter(torch.tensor(0.0)),
+            iso_hardening, kin_hardening)
+
+    ri_flowrule_base = flowrules.IsoKinViscoplasticity(n, eta,
+            s0, iso_hardening, kin_hardening)
+    ri_flowrule = flowrules.RateIndependentFlowRuleWrapper(ri_flowrule_base,
+            lmbda, eps0_ri)
+
+    flowrule = flowrules.KocksMeckingRegimeFlowRule(ri_flowrule, rd_flowrule,
+            g0, mu, b, eps0, k)
+
+    model = models.InelasticModel(E, flowrule)
+    integrator = models.ModelIntegrator(model)
+    
+    ngrid = 10
+    nsteps = 200
+    elimits = torch.ones(ngrid) * 0.05
+
+    # Constant temperature, varying flow rate
+    erates = torch.logspace(-5,-9,ngrid)
+    temps = torch.ones_like(erates) * (575 + 273.15)
+    g_rate = k * temps / (mu.value(temps) * b**3.0) * torch.log(eps0 / erates)
+
+    times, strains, temperatures, cyclces = experiments.make_tension_tests(
+            erates, temps, elimits, nsteps)
+
+    results_rate = integrator.solve_strain(times, strains, temperatures)
+    yield_rate = calculate_yield(strains, results_rate[:,:,0])
+    norm_rate = yield_rate / mu.value(temps)
+
+    # Constant flow rate, varying temperature
+    temps = torch.linspace(400+273.15, 1000+273.15, ngrid)
+    erates = torch.ones_like(temps) * 8.33e-5
+    g_temp = k * temps / (mu.value(temps) * b**3.0) * torch.log(eps0 / erates)
+
+    times, strains, temperatures, cyclces = experiments.make_tension_tests(
+            erates, temps, elimits, nsteps)
+
+    results_temp = integrator.solve_strain(times, strains, temperatures)
+    yield_temp = calculate_yield(strains, results_temp[:,:,0])
+    norm_temp = yield_temp / mu.value(temps)
+
+    plt.semilogy(g_rate.numpy(), norm_rate.numpy(), color = 'tab:blue', ls = 'none',
+            marker = 'x', label = "Varying rate")
+    plt.semilogy(g_temp.numpy(), norm_temp.numpy(), color = 'tab:orange', ls = 'none',
+            marker = 'x', label = "Varying temperature")
+    plt.axvline(x = g0, ls = '--', color = 'k')
+    plt.legend(loc='best')
+    plt.xlabel("Normalized activation energy")
+    plt.ylabel("Normalized flow stress")
+    plt.show()
+

--- a/examples/structural-material-models/kocks-mecking.py
+++ b/examples/structural-material-models/kocks-mecking.py
@@ -19,7 +19,8 @@ from pyoptmat import models, flowrules, experiments, hardening, temperature
 
 torch.set_default_tensor_type(torch.DoubleTensor)
 
-def calculate_yield(strain, stress, offset = 0.2/100.0):
+
+def calculate_yield(strain, stress, offset=0.2 / 100.0):
     """
     Calculate the yield stress given a strain/stress history
 
@@ -34,15 +35,18 @@ def calculate_yield(strain, stress, offset = 0.2/100.0):
 
     first = (vals - stress) > 0
 
-    vals, inds = torch.max(first, dim = 0)
+    vals, inds = torch.max(first, dim=0)
 
     return torch.diag(stress[inds])
 
+
 if __name__ == "__main__":
     E = temperature.PolynomialScaling(
-            [-6.82798735e-05, 9.48207244e-02, -1.11026526e+02, 2.21183687e+05])
+        [-6.82798735e-05, 9.48207244e-02, -1.11026526e02, 2.21183687e05]
+    )
     mu = temperature.PolynomialScaling(
-            [-2.60610204e-05, 3.61911162e-02, -4.23765368e+01, 8.44212545e+04])
+        [-2.60610204e-05, 3.61911162e-02, -4.23765368e01, 8.44212545e04]
+    )
     g0 = torch.tensor(0.771)
     k = torch.tensor(1.38064e-20)
     b = torch.tensor(2.019e-7)
@@ -51,7 +55,7 @@ if __name__ == "__main__":
     A = torch.tensor(-3.35)
     B = torch.tensor(-3.23)
     C = torch.tensor(-5.82)
-    
+
     n = temperature.KMRateSensitivityScaling(A, mu, b, k)
     eta = temperature.KMViscosityScaling(A, B, mu, eps0, b, k)
     s0 = temperature.ShearModulusScaling(torch.exp(C), mu)
@@ -65,56 +69,76 @@ if __name__ == "__main__":
     iso_hardening = hardening.VoceIsotropicHardeningModel(R, d)
     kin_hardening = hardening.NoKinematicHardeningModel()
 
-    rd_flowrule = flowrules.IsoKinViscoplasticity(n, eta, 
-            temperature.ConstantParameter(torch.tensor(0.0)),
-            iso_hardening, kin_hardening)
+    rd_flowrule = flowrules.IsoKinViscoplasticity(
+        n,
+        eta,
+        temperature.ConstantParameter(torch.tensor(0.0)),
+        iso_hardening,
+        kin_hardening,
+    )
 
-    ri_flowrule_base = flowrules.IsoKinViscoplasticity(n, eta,
-            s0, iso_hardening, kin_hardening)
-    ri_flowrule = flowrules.RateIndependentFlowRuleWrapper(ri_flowrule_base,
-            lmbda, eps0_ri)
+    ri_flowrule_base = flowrules.IsoKinViscoplasticity(
+        n, eta, s0, iso_hardening, kin_hardening
+    )
+    ri_flowrule = flowrules.RateIndependentFlowRuleWrapper(
+        ri_flowrule_base, lmbda, eps0_ri
+    )
 
-    flowrule = flowrules.KocksMeckingRegimeFlowRule(ri_flowrule, rd_flowrule,
-            g0, mu, b, eps0, k)
+    flowrule = flowrules.KocksMeckingRegimeFlowRule(
+        ri_flowrule, rd_flowrule, g0, mu, b, eps0, k
+    )
 
     model = models.InelasticModel(E, flowrule)
     integrator = models.ModelIntegrator(model)
-    
+
     ngrid = 10
     nsteps = 200
     elimits = torch.ones(ngrid) * 0.05
 
     # Constant temperature, varying flow rate
-    erates = torch.logspace(-5,-9,ngrid)
+    erates = torch.logspace(-5, -9, ngrid)
     temps = torch.ones_like(erates) * (575 + 273.15)
     g_rate = k * temps / (mu.value(temps) * b**3.0) * torch.log(eps0 / erates)
 
     times, strains, temperatures, cyclces = experiments.make_tension_tests(
-            erates, temps, elimits, nsteps)
+        erates, temps, elimits, nsteps
+    )
 
     results_rate = integrator.solve_strain(times, strains, temperatures)
-    yield_rate = calculate_yield(strains, results_rate[:,:,0])
+    yield_rate = calculate_yield(strains, results_rate[:, :, 0])
     norm_rate = yield_rate / mu.value(temps)
 
     # Constant flow rate, varying temperature
-    temps = torch.linspace(400+273.15, 1000+273.15, ngrid)
+    temps = torch.linspace(400 + 273.15, 1000 + 273.15, ngrid)
     erates = torch.ones_like(temps) * 8.33e-5
     g_temp = k * temps / (mu.value(temps) * b**3.0) * torch.log(eps0 / erates)
 
     times, strains, temperatures, cyclces = experiments.make_tension_tests(
-            erates, temps, elimits, nsteps)
+        erates, temps, elimits, nsteps
+    )
 
     results_temp = integrator.solve_strain(times, strains, temperatures)
-    yield_temp = calculate_yield(strains, results_temp[:,:,0])
+    yield_temp = calculate_yield(strains, results_temp[:, :, 0])
     norm_temp = yield_temp / mu.value(temps)
 
-    plt.semilogy(g_rate.numpy(), norm_rate.numpy(), color = 'tab:blue', ls = 'none',
-            marker = 'x', label = "Varying rate")
-    plt.semilogy(g_temp.numpy(), norm_temp.numpy(), color = 'tab:orange', ls = 'none',
-            marker = 'x', label = "Varying temperature")
-    plt.axvline(x = g0, ls = '--', color = 'k')
-    plt.legend(loc='best')
+    plt.semilogy(
+        g_rate.numpy(),
+        norm_rate.numpy(),
+        color="tab:blue",
+        ls="none",
+        marker="x",
+        label="Varying rate",
+    )
+    plt.semilogy(
+        g_temp.numpy(),
+        norm_temp.numpy(),
+        color="tab:orange",
+        ls="none",
+        marker="x",
+        label="Varying temperature",
+    )
+    plt.axvline(x=g0, ls="--", color="k")
+    plt.legend(loc="best")
     plt.xlabel("Normalized activation energy")
     plt.ylabel("Normalized flow stress")
     plt.show()
-

--- a/examples/structural-material-models/rate_independent.py
+++ b/examples/structural-material-models/rate_independent.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+"""
+    This problem verifies the rate independent flow rule wrapper by comparing
+    a numerically integrated solution to the exact, analytic solution for a
+    simple load history.
+"""
+
+import sys
+
+sys.path.append("../..")
+
+import torch
+import numpy as np
+
+import matplotlib.pyplot as plt
+
+from pyoptmat import models, flowrules, experiments, hardening
+from pyoptmat.temperature import ConstantParameter as CP
+
+torch.set_default_tensor_type(torch.DoubleTensor)
+
+if __name__ == "__main__":
+    nrates = 5
+
+    erates = torch.logspace(-1,-5,nrates)
+    temps = torch.ones_like(erates)
+    elimits = torch.ones_like(erates) * 0.1
+
+    nsteps = 200
+
+    times, strains, temperatures, cycles = experiments.make_tension_tests(
+            erates, temps, elimits, nsteps
+    )
+
+    # Viscoplastic base model
+    E = CP(torch.tensor(100000.0))
+
+    n = CP(torch.tensor(5.0))
+    eta = CP(torch.tensor(50.0))
+    s0 = CP(torch.tensor(25.0))
+
+    R = CP(torch.tensor(100.0))
+    d = CP(torch.tensor(20.0))
+
+    iso_hardening = hardening.VoceIsotropicHardeningModel(R, d)
+    kin_hardening = hardening.NoKinematicHardeningModel()
+
+    base_flowrule = flowrules.IsoKinViscoplasticity(n, eta, s0, iso_hardening,
+            kin_hardening)
+
+    # Approximately rate independent flow rule
+    lmbda = torch.tensor(0.999)
+    eps_ref = torch.tensor(1e-10)
+
+    flowrule = flowrules.RateIndependentFlowRuleWrapper(base_flowrule, lmbda,
+            eps_ref)
+
+    base_model = models.InelasticModel(E, base_flowrule)
+    base_integrator = models.ModelIntegrator(base_model)
+
+    rd_stresses = base_integrator.solve_strain(times, strains, temperatures)[:,:,0]
+
+    model = models.InelasticModel(E, flowrule)
+    integrator = models.ModelIntegrator(model)
+
+    ri_stresses = integrator.solve_strain(times, strains, temperatures)[:,:,0]
+    
+    def analytic(strain):
+        Ev = E.value(0).numpy()
+        s0v = s0.value(0).numpy()
+        Rv = R.value(0).numpy()
+        dv = d.value(0).numpy()
+
+        pred = Ev * strain
+        plastic = pred > s0v
+        ystrain = s0v / Ev
+        pstrain = strain[plastic] - ystrain
+        pred[plastic] = s0v + Rv*(1.0 - np.exp(-dv * pstrain))
+
+        return pred
+
+    for i in range(nrates):
+        plt.plot(strains[:,i], ri_stresses[:,i], 'k-', lw = 3)
+        plt.plot(strains[:,i], rd_stresses[:,i], 'k--', lw = 3)
+
+        enp = strains[:,i].numpy()
+        exact = analytic(enp)
+        plt.plot(enp, exact, color = 'r', lw = 2, ls = ':')
+
+
+    plt.xlabel("Strain (mm/mm)")
+    plt.ylabel("Stress (MPa)")
+
+    plt.show()

--- a/examples/structural-material-models/stress_strain_control.py
+++ b/examples/structural-material-models/stress_strain_control.py
@@ -21,7 +21,8 @@
 """
 
 import sys
-sys.path.append('../..')
+
+sys.path.append("../..")
 
 import torch
 
@@ -32,79 +33,98 @@ from pyoptmat import models, flowrules, temperature, experiments, hardening
 torch.set_default_tensor_type(torch.DoubleTensor)
 
 if __name__ == "__main__":
-  # This example illustrates the temperature and rate sensitivity of
-  # Alloy 617 with the model given in:
-  # Messner, Phan, and Sham. IJPVP 2019.
+    # This example illustrates the temperature and rate sensitivity of
+    # Alloy 617 with the model given in:
+    # Messner, Phan, and Sham. IJPVP 2019.
 
-  # Setup test conditions
-  ntemps = 5
-  temps = torch.linspace(750, 950, ntemps)+273.15
-  elimits = torch.ones(ntemps) * 0.25
-  erates = torch.ones(ntemps) * 8.33e-5
+    # Setup test conditions
+    ntemps = 5
+    temps = torch.linspace(750, 950, ntemps) + 273.15
+    elimits = torch.ones(ntemps) * 0.25
+    erates = torch.ones(ntemps) * 8.33e-5
 
-  nsteps = 200
+    nsteps = 200
 
-  times, strains, temperatures, cycles = experiments.make_tension_tests(erates, temps, 
-      elimits, nsteps)
+    times, strains, temperatures, cycles = experiments.make_tension_tests(
+        erates, temps, elimits, nsteps
+    )
 
-  # Perfect viscoplastic model
-  A = torch.tensor(-8.679)
-  B = torch.tensor(-0.744)
-  mu = temperature.PolynomialScaling(
-      torch.tensor([-1.34689305e-02,-5.18806776e+00,7.86708330e+04]))
-  b = torch.tensor(2.474e-7)
-  k = torch.tensor(1.38064e-20)
-  eps0 = torch.tensor(1e10)
-  E = temperature.PolynomialScaling(
-      torch.tensor([-3.48056033e-02, -1.44398964e+01, 2.06464967e+05]))
+    # Perfect viscoplastic model
+    A = torch.tensor(-8.679)
+    B = torch.tensor(-0.744)
+    mu = temperature.PolynomialScaling(
+        torch.tensor([-1.34689305e-02, -5.18806776e00, 7.86708330e04])
+    )
+    b = torch.tensor(2.474e-7)
+    k = torch.tensor(1.38064e-20)
+    eps0 = torch.tensor(1e10)
+    E = temperature.PolynomialScaling(
+        torch.tensor([-3.48056033e-02, -1.44398964e01, 2.06464967e05])
+    )
 
-  
-  ih = hardening.VoceIsotropicHardeningModel(
-      temperature.ConstantParameter(torch.tensor(150.0)),
-      temperature.ConstantParameter(torch.tensor(10.0)))
-  kh = hardening.NoKinematicHardeningModel()
+    ih = hardening.VoceIsotropicHardeningModel(
+        temperature.ConstantParameter(torch.tensor(150.0)),
+        temperature.ConstantParameter(torch.tensor(10.0)),
+    )
+    kh = hardening.NoKinematicHardeningModel()
 
-  fr = flowrules.IsoKinViscoplasticity(
-      temperature.KMRateSensitivityScaling(A, mu, b, k),
-      temperature.KMViscosityScaling(A, B, mu, eps0, b, k),
-      temperature.ConstantParameter(0), 
-      ih, kh)
-  model = models.InelasticModel(E, fr)
-  integrator = models.ModelIntegrator(model)
+    fr = flowrules.IsoKinViscoplasticity(
+        temperature.KMRateSensitivityScaling(A, mu, b, k),
+        temperature.KMViscosityScaling(A, B, mu, eps0, b, k),
+        temperature.ConstantParameter(0),
+        ih,
+        kh,
+    )
+    model = models.InelasticModel(E, fr)
+    integrator = models.ModelIntegrator(model)
 
-  stresses = integrator.solve_strain(times, strains, temperatures)[:,:,0]
+    stresses = integrator.solve_strain(times, strains, temperatures)[:, :, 0]
 
-  # Now do it backwards!
-  strains_prime = integrator.solve_stress(times, stresses, temperatures)[:,:,0]
-  
-  plt.figure()
-  for ei, epi, Ti, si in zip(strains.T.numpy(), strains_prime.T.numpy(),
-      temperatures.T.numpy(), stresses.T.numpy()):
-    l, = plt.plot(ei, si, label = "T = %3.0fK" % Ti[0])
-    plt.plot(epi, si, label = None, ls = '--', color = l.get_color())
-  
-  plt.legend(loc='best')
-  plt.xlabel("Strain (mm/mm)")
-  plt.ylabel("Stress (Mpa)")
-  plt.title("Comparison between strain and stress control")
-  plt.show()
+    # Now do it backwards!
+    strains_prime = integrator.solve_stress(times, stresses, temperatures)[:, :, 0]
 
-  # Now do it both ways at once!
-  big_times = torch.cat((times,times), 1)
-  big_temperatures = torch.cat((temperatures, temperatures), 1)
-  big_data = torch.cat((strains, stresses), 1)
-  big_types = torch.zeros(2*ntemps)
-  big_types[ntemps:] = 1
+    plt.figure()
+    for ei, epi, Ti, si in zip(
+        strains.T.numpy(),
+        strains_prime.T.numpy(),
+        temperatures.T.numpy(),
+        stresses.T.numpy(),
+    ):
+        (l,) = plt.plot(ei, si, label="T = %3.0fK" % Ti[0])
+        plt.plot(epi, si, label=None, ls="--", color=l.get_color())
 
-  both_results = integrator.solve_both(big_times, big_temperatures, big_data, big_types)
+    plt.legend(loc="best")
+    plt.xlabel("Strain (mm/mm)")
+    plt.ylabel("Stress (Mpa)")
+    plt.title("Comparison between strain and stress control")
+    plt.show()
 
-  plt.figure()
-  for i in range(ntemps):
-    l, = plt.plot(strains[:,i], both_results[:,i,0], label = "T = %3.0fK" % Ti[i])
-    plt.plot(both_results[:,i+ntemps, 0], stresses[:,i], label = None, ls = '--', color = l.get_color())
+    # Now do it both ways at once!
+    big_times = torch.cat((times, times), 1)
+    big_temperatures = torch.cat((temperatures, temperatures), 1)
+    big_data = torch.cat((strains, stresses), 1)
+    big_types = torch.zeros(2 * ntemps)
+    big_types[ntemps:] = 1
 
-  plt.xlabel("Strain (mm/mm)")
-  plt.ylabel("Stress (MPa)")
-  plt.legend(loc='best')
-  plt.title("Running both strain and stress control at once")
-  plt.show()
+    both_results = integrator.solve_both(
+        big_times, big_temperatures, big_data, big_types
+    )
+
+    plt.figure()
+    for i in range(ntemps):
+        (l,) = plt.plot(
+            strains[:, i], both_results[:, i, 0], label="T = %3.0fK" % Ti[i]
+        )
+        plt.plot(
+            both_results[:, i + ntemps, 0],
+            stresses[:, i],
+            label=None,
+            ls="--",
+            color=l.get_color(),
+        )
+
+    plt.xlabel("Strain (mm/mm)")
+    plt.ylabel("Stress (MPa)")
+    plt.legend(loc="best")
+    plt.title("Running both strain and stress control at once")
+    plt.show()

--- a/pyoptmat/damage.py
+++ b/pyoptmat/damage.py
@@ -28,7 +28,7 @@ class NoDamage(DamageModel):
     def __init__(self):
         super().__init__()
 
-    def damage_rate(self, s, d, t, T):
+    def damage_rate(self, s, d, t, T, e):
         """
         The damage rate and the derivative wrt to the damage variable.
         Here it's just zero.
@@ -38,10 +38,11 @@ class NoDamage(DamageModel):
           d (torch.tensor):      current value of damage
           t (torch.tensor):      current time
           T (torch.tensor):      current temperature
+          e (torch.tensor):      total strain rate
         """
         return torch.zeros_like(s), torch.zeros_like(s)
 
-    def d_damage_rate_d_s(self, s, d, t, T):
+    def d_damage_rate_d_s(self, s, d, t, T, e):
         """
         Derivative of the damage rate with respect to the stress.
 
@@ -52,8 +53,24 @@ class NoDamage(DamageModel):
           d (torch.tensor):      current value of damage
           t (torch.tensor):      current time
           T (torch.tensor):      current temperature
+          e (torch.tensor):      total strain rate
         """
         return torch.zeros_like(s)
+
+    def d_damage_rate_d_e(self, s, d, t, T, e):
+        """
+        Derivative of the damage rate with respect to the strain rate
+
+        Here again it's zero
+
+        Args:
+          s (torch.tensor):      stress
+          d (torch.tensor):      current value of damage
+          t (torch.tensor):      current time
+          T (torch.tensor):      current temperature
+          e (torch.tensor):      total strain rate
+        """
+        return torch.zeros_like(e)
 
 
 class HayhurstLeckie(DamageModel):
@@ -80,7 +97,7 @@ class HayhurstLeckie(DamageModel):
         self.xi = xi
         self.phi = phi
 
-    def damage_rate(self, s, d, t, T):
+    def damage_rate(self, s, d, t, T, e):
         """
         Damage rate and the derivative of the rate with respect to the
         damage variable
@@ -90,6 +107,7 @@ class HayhurstLeckie(DamageModel):
           d (torch.tensor):      damage variable
           t (torch.tensor):      time
           T (torch.tensor):      temperature
+          e (torch.tensor):      total strain rate
         """
         return (torch.abs(s) / self.A(T)) ** self.xi(T) * (1 - d) ** (
             self.xi(T) - self.phi(T)
@@ -97,7 +115,7 @@ class HayhurstLeckie(DamageModel):
             self.xi(T) - self.phi(T) - 1
         )
 
-    def d_damage_rate_d_s(self, s, d, t, T):
+    def d_damage_rate_d_s(self, s, d, t, T, e):
         """
         Derivative of the damage rate with respect to the stress
 

--- a/pyoptmat/damage.py
+++ b/pyoptmat/damage.py
@@ -130,3 +130,18 @@ class HayhurstLeckie(DamageModel):
             * (1 - d) ** (self.xi(T) - self.phi(T))
             * torch.sign(s)
         )
+
+    def d_damage_rate_d_e(self, s, d, t, T, e):
+        """
+        Derivative of the damage rate with respect to the strain rate
+
+        Here again it's zero
+
+        Args:
+          s (torch.tensor):      stress
+          d (torch.tensor):      current value of damage
+          t (torch.tensor):      current time
+          T (torch.tensor):      current temperature
+          e (torch.tensor):      total strain rate
+        """
+        return torch.zeros_like(e)

--- a/pyoptmat/flowrules.py
+++ b/pyoptmat/flowrules.py
@@ -207,7 +207,10 @@ class RateIndependentFlowRuleWrapper(FlowRule):
                                                 of the flow rate with
                                                 respect to stress
         """
-        pass
+        base, dbase = self.base.flow_rate(s, h, t, T, e)
+        sf = self.scale(e)
+
+        return sf*base, sf*dbase
 
     def dflow_dhist(self, s, h, t, T, e):
         """
@@ -223,7 +226,7 @@ class RateIndependentFlowRuleWrapper(FlowRule):
         Returns:
           torch.tensor:       the derivative of the flow rate
         """
-        pass
+        return self.base.dflow_dhist(s, h, t, T, e) * self.scale(e)[:,None,None]
 
     def dflow_derate(self, s, h, t, T, e):
         """
@@ -240,7 +243,8 @@ class RateIndependentFlowRuleWrapper(FlowRule):
           torch.tensor:       derivative of flow rate with respect to the
                               internal variables
         """
-        pass
+        return self.base.dflow_derate(s, h, t, T, e) * self.scale(e
+                ) + self.base.flow_rate(s, h, t, T, e)[0] * self.dscale(e)
 
     def history_rate(self, s, h, t, T, e):
         """
@@ -259,7 +263,10 @@ class RateIndependentFlowRuleWrapper(FlowRule):
                                                 derivative of the history rate
                                                 with respect to history
         """
-        pass
+        rate, drate = self.base.history_rate(s, h, t, T, e)
+        sf = self.scale(e)
+
+        return sf[:,None]*rate, sf[:,None,None]*drate
 
     def dhist_dstress(self, s, h, t, T, e):
         """
@@ -275,7 +282,7 @@ class RateIndependentFlowRuleWrapper(FlowRule):
         Returns:
           torch.tensor:       the derivative of the flow rate
         """
-        pass
+        return self.scale(e)[:,None] * self.base.dhist_dstress(s, h, t, T, e)
 
     def dhist_derate(self, s, h, t, T, e):
         """
@@ -291,7 +298,9 @@ class RateIndependentFlowRuleWrapper(FlowRule):
         Returns:
           torch.tensor:       the derivative of the flow rate
         """
-        pass
+        return self.base.dhist_derate(s, h, t, T, e) * self.scale(e
+                )[:,None] + self.base.history_rate(s, h, t, T, e
+                        )[0] * self.dscale(e)[:,None]
 
 
 

--- a/pyoptmat/flowrules.py
+++ b/pyoptmat/flowrules.py
@@ -212,8 +212,8 @@ class SuperimposedFlowRule(FlowRule):
           torch.tensor:       derivative of flow rate with respect to the
                               internal variables
         """
-        res = torch.zeros(s.shape + (1,) + e.shape[1:], device = h.device)
-
+        res = torch.zeros(e.shape, device = h.device)
+        
         for o, n, model in zip(self.offsets, self.nhist_per, self.models):
             dratei = model.dflow_derate(s, h[:, o : o + n], t, T, e)
             res += dratei

--- a/pyoptmat/flowrules.py
+++ b/pyoptmat/flowrules.py
@@ -139,7 +139,7 @@ class RateIndependentFlowRuleWrapper(FlowRule):
         the original, rate dependent response and :math:`\\lambda \\approx 1` 
         gives an approximately rate independent response,
         :math:`\\dot{\\varepsilon}_{ref}` is a reference strain rate which
-        should be on the order of the applied strain rate,
+        should be several orders of magnitude smaller than the applied strain rate,
         and :math:`\\dot{\\varepsilon}` is the current, transient
         strain rate applied to the model.
 

--- a/pyoptmat/hardening.py
+++ b/pyoptmat/hardening.py
@@ -48,7 +48,7 @@ class HardeningModel(nn.Module):
         Returns:
           torch.tensor:       derivative with respect to the total rate
         """
-        return torch.zeros(h.shape + e.shape[1:], device = h.device)
+        return torch.zeros(h.shape, device = h.device)
 
 
 class IsotropicHardeningModel(HardeningModel):
@@ -1193,7 +1193,7 @@ class SuperimposedKinematicHardening(KinematicHardeningModel):
         Returns:
           torch.tensor:       derivative with respect to the total rate
         """
-        dhr = torch.zeros(h.shape + (1,), device=s.device)
+        dhr = torch.zeros(h.shape, device=s.device)
         for o, n, model in zip(self.offsets, self.nhist_per, self.models):
             dhr[:, o : o + n] = model.dhistory_rate_dtotalrate(s, h[:, o : o + n], t, ep, T, e)
 

--- a/pyoptmat/hardening.py
+++ b/pyoptmat/hardening.py
@@ -30,6 +30,26 @@ class HardeningModel(nn.Module):
     def __init__(self):
         super().__init__()
 
+    def dhistory_rate_dtotalrate(self, s, h, t, ep, T, e):
+        """
+        The derivative of the history rate with respect to the total
+        strain rate
+
+        This will be zero in most models
+
+        Args:
+          s (torch.tensor):   stress
+          h (torch.tensor):   history
+          t (torch.tensor):   time
+          ep (torch.tensor):  the inelastic strain rate
+          T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
+
+        Returns:
+          torch.tensor:       derivative with respect to the total rate
+        """
+        return torch.zeros(h.shape + e.shape[1:], device = h.device)
+
 
 class IsotropicHardeningModel(HardeningModel):
     """
@@ -94,7 +114,7 @@ class VoceIsotropicHardeningModel(IsotropicHardeningModel):
         """
         return 1
 
-    def history_rate(self, s, h, t, ep, T):
+    def history_rate(self, s, h, t, ep, T, e):
         """
         The rate evolving the internal variables
 
@@ -104,13 +124,14 @@ class VoceIsotropicHardeningModel(IsotropicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       internal variable rate
         """
         return torch.unsqueeze(self.d(T) * (self.R(T) - h[:, 0]) * torch.abs(ep), 1)
 
-    def dhistory_rate_dstress(self, s, h, t, ep, T):
+    def dhistory_rate_dstress(self, s, h, t, ep, T, e):
         """
         The derivative of this history rate with respect to the stress
 
@@ -120,13 +141,14 @@ class VoceIsotropicHardeningModel(IsotropicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to stress
         """
         return torch.zeros_like(h)
 
-    def dhistory_rate_dhistory(self, s, h, t, ep, T):
+    def dhistory_rate_dhistory(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the internal variables
 
@@ -136,6 +158,7 @@ class VoceIsotropicHardeningModel(IsotropicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to history
@@ -147,7 +170,7 @@ class VoceIsotropicHardeningModel(IsotropicHardeningModel):
             1,
         )
 
-    def dhistory_rate_derate(self, s, h, t, ep, T):
+    def dhistory_rate_derate(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the inelastic
         strain rate
@@ -158,6 +181,7 @@ class VoceIsotropicHardeningModel(IsotropicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to the inelastic rate
@@ -223,7 +247,7 @@ class Theta0VoceIsotropicHardeningModel(IsotropicHardeningModel):
         """
         return 1
 
-    def history_rate(self, s, h, t, ep, T):
+    def history_rate(self, s, h, t, ep, T, e):
         """
         The rate evolving the internal variables
 
@@ -233,6 +257,7 @@ class Theta0VoceIsotropicHardeningModel(IsotropicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       internal variable rate
@@ -241,7 +266,7 @@ class Theta0VoceIsotropicHardeningModel(IsotropicHardeningModel):
             self.theta(T) * (1.0 - h[:, 0] / self.tau(T)) * torch.abs(ep), 1
         )
 
-    def dhistory_rate_dstress(self, s, h, t, ep, T):
+    def dhistory_rate_dstress(self, s, h, t, ep, T, e):
         """
         The derivative of this history rate with respect to the stress
 
@@ -251,13 +276,14 @@ class Theta0VoceIsotropicHardeningModel(IsotropicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to stress
         """
         return torch.zeros_like(h)
 
-    def dhistory_rate_dhistory(self, s, h, t, ep, T):
+    def dhistory_rate_dhistory(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the internal variables
 
@@ -267,6 +293,7 @@ class Theta0VoceIsotropicHardeningModel(IsotropicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to history
@@ -278,7 +305,7 @@ class Theta0VoceIsotropicHardeningModel(IsotropicHardeningModel):
             1,
         )
 
-    def dhistory_rate_derate(self, s, h, t, ep, T):
+    def dhistory_rate_derate(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the inelastic
         strain rate
@@ -289,6 +316,7 @@ class Theta0VoceIsotropicHardeningModel(IsotropicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to the inelastic rate
@@ -354,7 +382,7 @@ class Theta0RecoveryVoceIsotropicHardeningModel(IsotropicHardeningModel):
         """
         return 1
 
-    def history_rate(self, s, h, t, ep, T):
+    def history_rate(self, s, h, t, ep, T, e):
         """
         The rate evolving the internal variables
 
@@ -364,6 +392,7 @@ class Theta0RecoveryVoceIsotropicHardeningModel(IsotropicHardeningModel):
           t:      time
           ep:     the inelastic strain rate
           T:      the temperature
+          e (torch.tensor):   total strain rate
         """
         return torch.unsqueeze(
             self.theta(T) * (1.0 - h[:, 0] / self.tau(T)) * torch.abs(ep)
@@ -373,7 +402,7 @@ class Theta0RecoveryVoceIsotropicHardeningModel(IsotropicHardeningModel):
             1,
         )
 
-    def dhistory_rate_dstress(self, s, h, t, ep, T):
+    def dhistory_rate_dstress(self, s, h, t, ep, T, e):
         """
         The derivative of this history rate with respect to the stress
 
@@ -383,10 +412,11 @@ class Theta0RecoveryVoceIsotropicHardeningModel(IsotropicHardeningModel):
           t:      time
           ep:     the inelastic strain rate
           T:      temperature
+          e (torch.tensor):   total strain rate
         """
         return torch.zeros_like(h)
 
-    def dhistory_rate_dhistory(self, s, h, t, ep, T):
+    def dhistory_rate_dhistory(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the internal variables
 
@@ -396,6 +426,7 @@ class Theta0RecoveryVoceIsotropicHardeningModel(IsotropicHardeningModel):
           t:      time
           ep:     the inelastic strain rate
           T:      temperature
+          e (torch.tensor):   total strain rate
         """
         recovery = (
             self.r2(T)
@@ -412,7 +443,7 @@ class Theta0RecoveryVoceIsotropicHardeningModel(IsotropicHardeningModel):
             - recovery
         )
 
-    def dhistory_rate_derate(self, s, h, t, ep, T):
+    def dhistory_rate_derate(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the inelastic
         strain rate
@@ -423,6 +454,7 @@ class Theta0RecoveryVoceIsotropicHardeningModel(IsotropicHardeningModel):
           t:      time
           ep:     the inelastic strain rate
           T:      temperature
+          e (torch.tensor):   total strain rate
         """
         return torch.unsqueeze(
             torch.unsqueeze(
@@ -478,7 +510,7 @@ class NoKinematicHardeningModel(KinematicHardeningModel):
         """
         return torch.zeros(h.shape[0], 0, device=h.device)
 
-    def history_rate(self, s, h, t, ep, T):
+    def history_rate(self, s, h, t, ep, T, e):
         """
         The history evolution rate.  Here this is an empty vector.
 
@@ -488,10 +520,11 @@ class NoKinematicHardeningModel(KinematicHardeningModel):
           t:      time
           ep:     the inelastic strain rate
           T:      the temperature
+          e (torch.tensor):   total strain rate
         """
         return torch.empty_like(h)
 
-    def dhistory_rate_dstress(self, s, h, t, ep, T):
+    def dhistory_rate_dstress(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the stress.
 
@@ -503,10 +536,11 @@ class NoKinematicHardeningModel(KinematicHardeningModel):
           t:      time
           ep:     the inelastic strain rate
           T:      temperature
+          e (torch.tensor):   total strain rate
         """
         return torch.empty_like(h)
 
-    def dhistory_rate_dhistory(self, s, h, t, ep, T):
+    def dhistory_rate_dhistory(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the history
 
@@ -518,10 +552,11 @@ class NoKinematicHardeningModel(KinematicHardeningModel):
           t:      time
           ep:     the inelastic strain rate
           T:      temperature
+          e (torch.tensor):   total strain rate
         """
         return torch.empty(h.shape[0], 0, 0, device=h.device)
 
-    def dhistory_rate_derate(self, s, h, t, ep, T):
+    def dhistory_rate_derate(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the inelastic
         strain rate.
@@ -534,6 +569,7 @@ class NoKinematicHardeningModel(KinematicHardeningModel):
           t:      time
           ep:     the inelastic strain rate
           T:      temperature
+          e (torch.tensor):   total strain rate
         """
         return torch.empty(h.shape[0], 0, 1, device=h.device)
 
@@ -608,7 +644,7 @@ class FAKinematicHardeningModel(KinematicHardeningModel):
         """
         return 1
 
-    def history_rate(self, s, h, t, ep, T):
+    def history_rate(self, s, h, t, ep, T, e):
         """
         The rate evolving the internal variables
 
@@ -618,6 +654,7 @@ class FAKinematicHardeningModel(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       internal variable rate
@@ -629,7 +666,7 @@ class FAKinematicHardeningModel(KinematicHardeningModel):
             1,
         )
 
-    def dhistory_rate_dstress(self, s, h, t, ep, T):
+    def dhistory_rate_dstress(self, s, h, t, ep, T, e):
         """
         The derivative of this history rate with respect to the stress
 
@@ -639,13 +676,14 @@ class FAKinematicHardeningModel(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to stress
         """
         return torch.zeros_like(h)
 
-    def dhistory_rate_dhistory(self, s, h, t, ep, T):
+    def dhistory_rate_dhistory(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the internal variables
 
@@ -655,6 +693,7 @@ class FAKinematicHardeningModel(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to history
@@ -666,7 +705,7 @@ class FAKinematicHardeningModel(KinematicHardeningModel):
             ]
         )
 
-    def dhistory_rate_derate(self, s, h, t, ep, T):
+    def dhistory_rate_derate(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the inelastic
         strain rate
@@ -677,6 +716,7 @@ class FAKinematicHardeningModel(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to the inelastic rate
@@ -752,7 +792,7 @@ class ChabocheHardeningModel(KinematicHardeningModel):
         """
         return self.nback
 
-    def history_rate(self, s, h, t, ep, T):
+    def history_rate(self, s, h, t, ep, T, e):
         """
         The rate evolving the internal variables
 
@@ -762,6 +802,7 @@ class ChabocheHardeningModel(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       internal variable rate
@@ -771,7 +812,7 @@ class ChabocheHardeningModel(KinematicHardeningModel):
             - self.g(T)[None, ...] * h * torch.abs(ep)[:, None]
         ).reshape(h.shape)
 
-    def dhistory_rate_dstress(self, s, h, t, ep, T):
+    def dhistory_rate_dstress(self, s, h, t, ep, T, e):
         """
         The derivative of this history rate with respect to the stress
 
@@ -781,13 +822,14 @@ class ChabocheHardeningModel(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to stress
         """
         return torch.zeros_like(h)
 
-    def dhistory_rate_dhistory(self, s, h, t, ep, T):
+    def dhistory_rate_dhistory(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the internal variables
 
@@ -797,6 +839,7 @@ class ChabocheHardeningModel(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to history
@@ -805,7 +848,7 @@ class ChabocheHardeningModel(KinematicHardeningModel):
             h.shape + h.shape[1:]
         )
 
-    def dhistory_rate_derate(self, s, h, t, ep, T):
+    def dhistory_rate_derate(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the inelastic
         strain rate
@@ -816,6 +859,7 @@ class ChabocheHardeningModel(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to the inelastic rate
@@ -900,7 +944,7 @@ class ChabocheHardeningModelRecovery(KinematicHardeningModel):
         """
         return self.nback
 
-    def history_rate(self, s, h, t, ep, T):
+    def history_rate(self, s, h, t, ep, T, e):
         """
         The rate evolving the internal variables
 
@@ -910,6 +954,7 @@ class ChabocheHardeningModelRecovery(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       internal variable rate
@@ -920,7 +965,7 @@ class ChabocheHardeningModelRecovery(KinematicHardeningModel):
             - self.b(T)[None, ...] * torch.abs(h) ** (self.r(T)[None, ...] - 1.0) * h
         ).reshape(h.shape)
 
-    def dhistory_rate_dstress(self, s, h, t, ep, T):
+    def dhistory_rate_dstress(self, s, h, t, ep, T, e):
         """
         The derivative of this history rate with respect to the stress
 
@@ -930,13 +975,14 @@ class ChabocheHardeningModelRecovery(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to stress
         """
         return torch.zeros_like(h)
 
-    def dhistory_rate_dhistory(self, s, h, t, ep, T):
+    def dhistory_rate_dhistory(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the internal variables
 
@@ -946,6 +992,7 @@ class ChabocheHardeningModelRecovery(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to history
@@ -960,7 +1007,7 @@ class ChabocheHardeningModelRecovery(KinematicHardeningModel):
             h.shape + h.shape[1:]
         )
 
-    def dhistory_rate_derate(self, s, h, t, ep, T):
+    def dhistory_rate_derate(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the inelastic
         strain rate
@@ -971,6 +1018,7 @@ class ChabocheHardeningModelRecovery(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to the inelastic rate
@@ -1039,7 +1087,7 @@ class SuperimposedKinematicHardening(KinematicHardeningModel):
         """
         return sum(self.nhist_per)
 
-    def history_rate(self, s, h, t, ep, T):
+    def history_rate(self, s, h, t, ep, T, e):
         """
         The rate evolving the internal variables
 
@@ -1049,17 +1097,19 @@ class SuperimposedKinematicHardening(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       internal variable rate
         """
         hr = torch.zeros_like(h)
         for o, n, model in zip(self.offsets, self.nhist_per, self.models):
-            hr[:, o : o + n] = model.history_rate(s, h[:, o : o + n], t, ep, T)
+            hr[:, o : o + n] = model.history_rate(s, h[:, o : o + n], t, ep, T,
+                    e)
 
         return hr
 
-    def dhistory_rate_dstress(self, s, h, t, ep, T):
+    def dhistory_rate_dstress(self, s, h, t, ep, T, e):
         """
         The derivative of this history rate with respect to the stress
 
@@ -1069,6 +1119,7 @@ class SuperimposedKinematicHardening(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to stress
@@ -1076,12 +1127,12 @@ class SuperimposedKinematicHardening(KinematicHardeningModel):
         dhr = torch.zeros_like(h)
         for o, n, model in zip(self.offsets, self.nhist_per, self.models):
             dhr[:, o : o + n] = model.dhistory_rate_dstress(
-                s, h[:, o : o + n], t, ep, T
+                s, h[:, o : o + n], t, ep, T, e
             )
 
         return dhr
 
-    def dhistory_rate_dhistory(self, s, h, t, ep, T):
+    def dhistory_rate_dhistory(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the internal variables
 
@@ -1091,6 +1142,7 @@ class SuperimposedKinematicHardening(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to history
@@ -1098,12 +1150,12 @@ class SuperimposedKinematicHardening(KinematicHardeningModel):
         dhr = torch.zeros(h.shape[0], self.nhist, self.nhist, device=s.device)
         for o, n, model in zip(self.offsets, self.nhist_per, self.models):
             dhr[:, o : o + n, o : o + n] = model.dhistory_rate_dhistory(
-                s, h[:, o : o + n], t, ep, T
+                s, h[:, o : o + n], t, ep, T, e
             )
 
         return dhr
 
-    def dhistory_rate_derate(self, s, h, t, ep, T):
+    def dhistory_rate_derate(self, s, h, t, ep, T, e):
         """
         The derivative of the history rate with respect to the inelastic
         strain rate
@@ -1114,12 +1166,35 @@ class SuperimposedKinematicHardening(KinematicHardeningModel):
           t (torch.tensor):   time
           ep (torch.tensor):  the inelastic strain rate
           T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
 
         Returns:
           torch.tensor:       derivative with respect to the inelastic rate
         """
         dhr = torch.zeros(h.shape + (1,), device=s.device)
         for o, n, model in zip(self.offsets, self.nhist_per, self.models):
-            dhr[:, o : o + n] = model.dhistory_rate_derate(s, h[:, o : o + n], t, ep, T)
+            dhr[:, o : o + n] = model.dhistory_rate_derate(s, h[:, o : o + n], t, ep, T, e)
+
+        return dhr
+
+    def dhistory_rate_dtotalrate(self, s, h, t, ep, T, e):
+        """
+        The derivative of the history rate with respect to the total
+        strain rate
+
+        Args:
+          s (torch.tensor):   stress
+          h (torch.tensor):   history
+          t (torch.tensor):   time
+          ep (torch.tensor):  the inelastic strain rate
+          T (torch.tensor):   the temperature
+          e (torch.tensor):   total strain rate
+
+        Returns:
+          torch.tensor:       derivative with respect to the total rate
+        """
+        dhr = torch.zeros(h.shape + (1,), device=s.device)
+        for o, n, model in zip(self.offsets, self.nhist_per, self.models):
+            dhr[:, o : o + n] = model.dhistory_rate_dtotalrate(s, h[:, o : o + n], t, ep, T, e)
 
         return dhr

--- a/pyoptmat/hardening.py
+++ b/pyoptmat/hardening.py
@@ -48,7 +48,7 @@ class HardeningModel(nn.Module):
         Returns:
           torch.tensor:       derivative with respect to the total rate
         """
-        return torch.zeros(h.shape, device = h.device)
+        return torch.zeros(h.shape, device=h.device)
 
 
 class IsotropicHardeningModel(HardeningModel):
@@ -1104,8 +1104,7 @@ class SuperimposedKinematicHardening(KinematicHardeningModel):
         """
         hr = torch.zeros_like(h)
         for o, n, model in zip(self.offsets, self.nhist_per, self.models):
-            hr[:, o : o + n] = model.history_rate(s, h[:, o : o + n], t, ep, T,
-                    e)
+            hr[:, o : o + n] = model.history_rate(s, h[:, o : o + n], t, ep, T, e)
 
         return hr
 
@@ -1173,7 +1172,9 @@ class SuperimposedKinematicHardening(KinematicHardeningModel):
         """
         dhr = torch.zeros(h.shape + (1,), device=s.device)
         for o, n, model in zip(self.offsets, self.nhist_per, self.models):
-            dhr[:, o : o + n] = model.dhistory_rate_derate(s, h[:, o : o + n], t, ep, T, e)
+            dhr[:, o : o + n] = model.dhistory_rate_derate(
+                s, h[:, o : o + n], t, ep, T, e
+            )
 
         return dhr
 
@@ -1195,6 +1196,8 @@ class SuperimposedKinematicHardening(KinematicHardeningModel):
         """
         dhr = torch.zeros(h.shape, device=s.device)
         for o, n, model in zip(self.offsets, self.nhist_per, self.models):
-            dhr[:, o : o + n] = model.dhistory_rate_dtotalrate(s, h[:, o : o + n], t, ep, T, e)
+            dhr[:, o : o + n] = model.dhistory_rate_dtotalrate(
+                s, h[:, o : o + n], t, ep, T, e
+            )
 
         return dhr

--- a/pyoptmat/models.py
+++ b/pyoptmat/models.py
@@ -82,20 +82,21 @@ class InelasticModel(nn.Module):
           y_dot:          (nbatch,1+nhist+1) state rate
           d_y_dot_d_y:    (nbatch,1+nhist+1,1+nhist+1) Jacobian wrt the state
           d_y_dot_d_erate:(nbatch,1+nhist+1) Jacobian wrt the strain rate
+          d_y_dot_d_T:    (nbatch,1+nhist+1) derivative wrt temperature (unused)
         """
         stress = y[:, 0].clone()
         h = y[:, 1 : 1 + self.flowrule.nhist].clone()
         d = y[:, -1].clone()
 
-        frate, dfrate = self.flowrule.flow_rate(stress / (1 - d), h, t, T)
-        hrate, dhrate = self.flowrule.history_rate(stress / (1 - d), h, t, T)
-        drate, ddrate = self.dmodel.damage_rate(stress / (1 - d), d, t, T)
+        frate, dfrate = self.flowrule.flow_rate(stress / (1 - d), h, t, T, erate)
+        hrate, dhrate = self.flowrule.history_rate(stress / (1 - d), h, t, T, erate)
+        drate, ddrate = self.dmodel.damage_rate(stress / (1 - d), d, t, T, erate)
 
         # Modify for damage
         frate_p = (1 - d) * frate - drate * stress
         dfrate_p = (
             dfrate
-            - self.dmodel.d_damage_rate_d_s(stress / (1 - d), d, t, T) / (1 - d)
+            - self.dmodel.d_damage_rate_d_s(stress / (1 - d), d, t, T, erate) / (1 - d)
             - drate
         )
 
@@ -111,34 +112,39 @@ class InelasticModel(nn.Module):
         dresult[:, 0:1, 1 : 1 + self.flowrule.nhist] = (
             -self.E(T)[..., None, None]
             * (1 - d)[:, None, None]
-            * self.flowrule.dflow_dhist(stress / (1 - d), h, t, T)
+            * self.flowrule.dflow_dhist(stress / (1 - d), h, t, T, erate)
         )
         dresult[:, 0, -1] = self.E(T) * (frate - dfrate * stress / (1 - d))
 
         dresult[:, 1 : 1 + self.flowrule.nhist, 0] = (
-            self.flowrule.dhist_dstress(stress / (1 - d), h, t, T) / (1 - d)[:, None]
+            self.flowrule.dhist_dstress(stress / (1 - d), h, t, T, erate) / (1 - d)[:, None]
         )
         dresult[:, 1 : 1 + self.flowrule.nhist, 1 : 1 + self.flowrule.nhist] = dhrate
         dresult[:, 1 : 1 + self.flowrule.nhist, -1] = (
-            self.flowrule.dhist_dstress(stress / (1 - d), h, t, T)
+            self.flowrule.dhist_dstress(stress / (1 - d), h, t, T, erate)
             * stress[:, None]
             / (1 - d[:, None]) ** 2
         )
 
-        dresult[:, -1, 0] = self.dmodel.d_damage_rate_d_s(stress / (1 - d), d, t, T) / (
+        dresult[:, -1, 0] = self.dmodel.d_damage_rate_d_s(stress / (1 - d), d, t, T, erate) / (
             1 - d
         )
         # d_damage_d_hist is zero
         dresult[:, -1, -1] = ddrate
 
         # Calculate the derivative wrt the strain rate, used in inverting
+        # TODO reconsider in light of frate_p above 
         drate = torch.zeros_like(y)
-        drate[:, 0] = self.E(T)
+        drate[:, 0] = self.E(T)*(1.0 - self.flowrule.dflow_derate(stress / (1-d), h, t, T, erate) - 
+                dfrate_p * self.dmodel.d_damage_rate_d_e(stress / (1-d), d, t, T, erate))
+        drate[:, 1 : 1 + self.flowrule.nhist] = self.flowrule.dhist_derate(stress / (1-d), h, t, T, erate
+                ) + d
+        drate[:, -1] = 0.0 # Wrong
 
         # Logically we should return the derivative wrt T, but right now
         # we're not going to use it
         Trate = torch.zeros_like(y)
-
+        
         return result, dresult, drate, Trate
 
 

--- a/pyoptmat/models.py
+++ b/pyoptmat/models.py
@@ -117,7 +117,8 @@ class InelasticModel(nn.Module):
         dresult[:, 0, -1] = self.E(T) * (frate - dfrate * stress / (1 - d))
 
         dresult[:, 1 : 1 + self.flowrule.nhist, 0] = (
-            self.flowrule.dhist_dstress(stress / (1 - d), h, t, T, erate) / (1 - d)[:, None]
+            self.flowrule.dhist_dstress(stress / (1 - d), h, t, T, erate)
+            / (1 - d)[:, None]
         )
         dresult[:, 1 : 1 + self.flowrule.nhist, 1 : 1 + self.flowrule.nhist] = dhrate
         dresult[:, 1 : 1 + self.flowrule.nhist, -1] = (
@@ -126,23 +127,28 @@ class InelasticModel(nn.Module):
             / (1 - d[:, None]) ** 2
         )
 
-        dresult[:, -1, 0] = self.dmodel.d_damage_rate_d_s(stress / (1 - d), d, t, T, erate) / (
-            1 - d
-        )
+        dresult[:, -1, 0] = self.dmodel.d_damage_rate_d_s(
+            stress / (1 - d), d, t, T, erate
+        ) / (1 - d)
         # d_damage_d_hist is zero
         dresult[:, -1, -1] = ddrate
 
         # Calculate the derivative wrt the strain rate, used in inverting
         drate = torch.zeros_like(y)
-        drate[:, 0] = self.E(T)*(1.0 - (1-d) * self.flowrule.dflow_derate(stress / (1-d), h, t, T, erate) - 
-                 self.dmodel.d_damage_rate_d_e(stress / (1-d), d, t, T, erate) * stress)
-        drate[:, 1 : 1 + self.flowrule.nhist] = self.flowrule.dhist_derate(stress / (1-d), h, t, T, erate)
-        drate[:, -1] = self.dmodel.d_damage_rate_d_e(stress / (1-d), d, t, T, erate)
+        drate[:, 0] = self.E(T) * (
+            1.0
+            - (1 - d) * self.flowrule.dflow_derate(stress / (1 - d), h, t, T, erate)
+            - self.dmodel.d_damage_rate_d_e(stress / (1 - d), d, t, T, erate) * stress
+        )
+        drate[:, 1 : 1 + self.flowrule.nhist] = self.flowrule.dhist_derate(
+            stress / (1 - d), h, t, T, erate
+        )
+        drate[:, -1] = self.dmodel.d_damage_rate_d_e(stress / (1 - d), d, t, T, erate)
 
         # Logically we should return the derivative wrt T, but right now
         # we're not going to use it
         Trate = torch.zeros_like(y)
-        
+
         return result, dresult, drate, Trate
 
 

--- a/test/test_damage.py
+++ b/test/test_damage.py
@@ -12,16 +12,23 @@ torch.set_default_dtype(torch.float64)
 
 class DamageBase:
     def test_d_rate(self):
-        exact = self.model.damage_rate(self.s, self.d, self.t, self.T)[1]
+        exact = self.model.damage_rate(self.s, self.d, self.t, self.T, self.erate)[1]
         numer = utility.differentiate(
-            lambda x: self.model.damage_rate(self.s, x, self.t, self.T)[0], self.d
+            lambda x: self.model.damage_rate(self.s, x, self.t, self.T, self.erate)[0], self.d
         )
         self.assertTrue(np.allclose(exact, numer))
 
     def test_d_stress(self):
-        exact = self.model.d_damage_rate_d_s(self.s, self.d, self.t, self.T)
+        exact = self.model.d_damage_rate_d_s(self.s, self.d, self.t, self.T, self.erate)
         numer = utility.differentiate(
-            lambda x: self.model.damage_rate(x, self.d, self.t, self.T)[0], self.s
+            lambda x: self.model.damage_rate(x, self.d, self.t, self.T, self.erate)[0], self.s
+        )
+        self.assertTrue(np.allclose(exact, numer))
+
+    def test_d_erate(self):
+        exact = self.model.d_damage_rate_d_e(self.s, self.d, self.t, self.T, self.erate)
+        numer = utility.differentiate(
+            lambda x: self.model.damage_rate(self.s, self.d, self.t, self.T, x)[0], self.erate
         )
         self.assertTrue(np.allclose(exact, numer))
 
@@ -36,11 +43,12 @@ class TestNoDamage(unittest.TestCase, DamageBase):
         self.d = torch.linspace(0.1, 0.5, self.nbatch)
         self.t = torch.ones(self.nbatch)
         self.T = torch.zeros_like(self.t)
+        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
 
     def test_damage_rate(self):
         self.assertTrue(
             np.allclose(
-                self.model.damage_rate(self.s, self.d, self.t, self.T)[0],
+                self.model.damage_rate(self.s, self.d, self.t, self.T, self.erate)[0],
                 torch.zeros_like(self.s),
             )
         )
@@ -59,11 +67,13 @@ class TestHLDamage(unittest.TestCase, DamageBase):
         self.d = torch.linspace(0.1, 0.5, self.nbatch)
         self.t = torch.ones(self.nbatch)
         self.T = torch.zeros_like(self.t)
+        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
+
 
     def test_damage_rate(self):
         self.assertTrue(
             np.allclose(
-                self.model.damage_rate(self.s, self.d, self.t, self.T)[0],
+                self.model.damage_rate(self.s, self.d, self.t, self.T, self.erate)[0],
                 (self.s / self.A) ** (self.xi) * (1 - self.d) ** (self.xi - self.phi),
             )
         )

--- a/test/test_damage.py
+++ b/test/test_damage.py
@@ -14,21 +14,24 @@ class DamageBase:
     def test_d_rate(self):
         exact = self.model.damage_rate(self.s, self.d, self.t, self.T, self.erate)[1]
         numer = utility.differentiate(
-            lambda x: self.model.damage_rate(self.s, x, self.t, self.T, self.erate)[0], self.d
+            lambda x: self.model.damage_rate(self.s, x, self.t, self.T, self.erate)[0],
+            self.d,
         )
         self.assertTrue(np.allclose(exact, numer))
 
     def test_d_stress(self):
         exact = self.model.d_damage_rate_d_s(self.s, self.d, self.t, self.T, self.erate)
         numer = utility.differentiate(
-            lambda x: self.model.damage_rate(x, self.d, self.t, self.T, self.erate)[0], self.s
+            lambda x: self.model.damage_rate(x, self.d, self.t, self.T, self.erate)[0],
+            self.s,
         )
         self.assertTrue(np.allclose(exact, numer))
 
     def test_d_erate(self):
         exact = self.model.d_damage_rate_d_e(self.s, self.d, self.t, self.T, self.erate)
         numer = utility.differentiate(
-            lambda x: self.model.damage_rate(self.s, self.d, self.t, self.T, x)[0], self.erate
+            lambda x: self.model.damage_rate(self.s, self.d, self.t, self.T, x)[0],
+            self.erate,
         )
         self.assertTrue(np.allclose(exact, numer))
 
@@ -43,7 +46,7 @@ class TestNoDamage(unittest.TestCase, DamageBase):
         self.d = torch.linspace(0.1, 0.5, self.nbatch)
         self.t = torch.ones(self.nbatch)
         self.T = torch.zeros_like(self.t)
-        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
+        self.erate = torch.linspace(1e-2, 1e-3, self.nbatch)
 
     def test_damage_rate(self):
         self.assertTrue(
@@ -67,8 +70,7 @@ class TestHLDamage(unittest.TestCase, DamageBase):
         self.d = torch.linspace(0.1, 0.5, self.nbatch)
         self.t = torch.ones(self.nbatch)
         self.T = torch.zeros_like(self.t)
-        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
-
+        self.erate = torch.linspace(1e-2, 1e-3, self.nbatch)
 
     def test_damage_rate(self):
         self.assertTrue(

--- a/test/test_flowrules.py
+++ b/test/test_flowrules.py
@@ -57,8 +57,7 @@ class CommonFlowRule:
         numer = utility.new_differentiate(
             lambda x: self.model.flow_rate(self.s, self.h, self.t, self.T, x)[0], self.erate
         )
-
-        self.assertTrue(np.allclose(exact, numer, rtol=1.0e-4))
+        self.assertTrue(np.allclose(exact, torch.flatten(numer), rtol=1.0e-4))
 
     def test_history_erate(self):
         if self.skip:
@@ -88,6 +87,50 @@ class TestPerfectViscoplasticity(unittest.TestCase, CommonFlowRule):
         self.T = torch.zeros_like(self.t)
         self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
 
+
+class TestWrappedRIIsoKinViscoplasticity(unittest.TestCase, CommonFlowRule):
+    def setUp(self):
+        self.n = torch.tensor(5.2)
+        self.eta = torch.tensor(110.0)
+        self.s0 = torch.tensor(11.0)
+
+        self.nbatch = 10
+
+        self.R = torch.tensor(101.0)
+        self.d = torch.tensor(1.3)
+        self.iso = hardening.VoceIsotropicHardeningModel(CP(self.R), CP(self.d))
+
+        self.C = torch.tensor(1200.0)
+        self.g = torch.tensor(10.1)
+        self.kin = hardening.FAKinematicHardeningModel(CP(self.C), CP(self.g))
+
+        self.bmodel = flowrules.IsoKinViscoplasticity(
+            CP(self.n), CP(self.eta), CP(self.s0), self.iso, self.kin
+        )
+        
+        self.l = 0.5
+        self.eps_ref = 1e-4
+        self.model = flowrules.RateIndependentFlowRuleWrapper(self.bmodel,
+                self.l, self.eps_ref)
+
+        self.s = torch.linspace(150, 200, self.nbatch)
+        self.h = torch.reshape(
+            torch.tensor(
+                np.array(
+                    [
+                        np.linspace(51, 110, self.nbatch),
+                        np.linspace(-100, 210, self.nbatch)[::-1],
+                    ]
+                )
+            ).T,
+            (self.nbatch, 2),
+        )
+
+        self.t = torch.ones(self.nbatch)
+        self.T = torch.zeros_like(self.t)
+        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
+
+        self.skip = False
 
 class TestIsoKinViscoplasticity(unittest.TestCase, CommonFlowRule):
     def setUp(self):

--- a/test/test_flowrules.py
+++ b/test/test_flowrules.py
@@ -132,6 +132,71 @@ class TestWrappedRIIsoKinViscoplasticity(unittest.TestCase, CommonFlowRule):
 
         self.skip = False
 
+class TestKocksMeckingRegimeFlowRule(unittest.TestCase, CommonFlowRule):
+    def setUp(self):
+        self.nbatch = 10
+
+        self.n1 = torch.tensor(5.2)
+        self.eta1 = torch.tensor(110.0)
+        self.s01 = torch.tensor(11.0)
+
+        self.R1 = torch.tensor(101.0)
+        self.d1 = torch.tensor(1.3)
+        self.iso1 = hardening.VoceIsotropicHardeningModel(CP(self.R1), CP(self.d1))
+
+        self.C1 = torch.tensor(1200.0)
+        self.g1 = torch.tensor(10.1)
+        self.kin1 = hardening.FAKinematicHardeningModel(CP(self.C1), CP(self.g1))
+
+        self.model1 = flowrules.IsoKinViscoplasticity(
+            CP(self.n1), CP(self.eta1), CP(self.s01), self.iso1, self.kin1
+        )
+        
+        self.n2 = torch.tensor(5.2)
+        self.eta2 = torch.tensor(110.0)
+        self.s02 = torch.tensor(11.0)
+
+        self.R2 = torch.tensor(101.0)
+        self.d2 = torch.tensor(1.3)
+        self.iso2 = hardening.VoceIsotropicHardeningModel(CP(self.R2), CP(self.d2))
+
+        self.C2 = torch.tensor(1200.0)
+        self.g2 = torch.tensor(10.1)
+        self.kin2 = hardening.FAKinematicHardeningModel(CP(self.C2), CP(self.g2))
+
+        self.model2 = flowrules.IsoKinViscoplasticity(
+            CP(self.n2), CP(self.eta2), CP(self.s02), self.iso2, self.kin2
+        )
+
+        self.mu = CP(1000.0)
+        self.b = 1.0
+        self.eps0 = 1.0
+        self.k = 1.0
+
+        self.g0 = 1.5
+
+        self.model = flowrules.KocksMeckingRegimeFlowRule(self.model1, self.model2, 
+                self.g0, self.mu, self.b, self.eps0, self.k)
+
+        self.s = torch.linspace(150, 200, self.nbatch)
+        self.h = torch.reshape(
+            torch.tensor(
+                np.array(
+                    [
+                        np.linspace(51, 110, self.nbatch),
+                        np.linspace(-100, 210, self.nbatch)[::-1],
+                    ]
+                )
+            ).T,
+            (self.nbatch, 2),
+        )
+
+        self.t = torch.ones(self.nbatch)
+        self.T = torch.ones_like(self.t) * 300
+        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
+
+        self.skip = False
+
 class TestIsoKinViscoplasticity(unittest.TestCase, CommonFlowRule):
     def setUp(self):
         self.n = torch.tensor(5.2)

--- a/test/test_flowrules.py
+++ b/test/test_flowrules.py
@@ -14,7 +14,8 @@ class CommonFlowRule:
     def test_flow_rate(self):
         exact = self.model.flow_rate(self.s, self.h, self.t, self.T, self.erate)[1]
         numer = utility.differentiate(
-            lambda x: self.model.flow_rate(x, self.h, self.t, self.T, self.erate)[0], self.s
+            lambda x: self.model.flow_rate(x, self.h, self.t, self.T, self.erate)[0],
+            self.s,
         )
 
         self.assertTrue(np.allclose(exact, numer, rtol=1.0e-4))
@@ -23,9 +24,12 @@ class CommonFlowRule:
         if self.skip:
             return
 
-        test, exact = self.model.history_rate(self.s, self.h, self.t, self.T, self.erate)
+        test, exact = self.model.history_rate(
+            self.s, self.h, self.t, self.T, self.erate
+        )
         numer = utility.new_differentiate(
-            lambda x: self.model.history_rate(self.s, x, self.t, self.T, self.erate)[0], self.h
+            lambda x: self.model.history_rate(self.s, x, self.t, self.T, self.erate)[0],
+            self.h,
         )
 
         self.assertTrue(np.allclose(exact, numer, rtol=1.0e-4))
@@ -36,7 +40,8 @@ class CommonFlowRule:
 
         exact = self.model.dflow_dhist(self.s, self.h, self.t, self.T, self.erate)
         numer = utility.new_differentiate(
-            lambda x: self.model.flow_rate(self.s, x, self.t, self.T, self.erate)[0], self.h
+            lambda x: self.model.flow_rate(self.s, x, self.t, self.T, self.erate)[0],
+            self.h,
         )
 
         self.assertTrue(np.allclose(exact, numer, rtol=1.0e-4))
@@ -47,7 +52,8 @@ class CommonFlowRule:
 
         exact = self.model.dhist_dstress(self.s, self.h, self.t, self.T, self.erate)
         numer = utility.new_differentiate(
-            lambda x: self.model.history_rate(x, self.h, self.t, self.T, self.erate)[0], self.s
+            lambda x: self.model.history_rate(x, self.h, self.t, self.T, self.erate)[0],
+            self.s,
         )[..., 0]
 
         self.assertTrue(np.allclose(exact, numer, rtol=1.0e-4))
@@ -55,7 +61,8 @@ class CommonFlowRule:
     def test_flow_erate(self):
         exact = self.model.dflow_derate(self.s, self.h, self.t, self.T, self.erate)
         numer = utility.new_differentiate(
-            lambda x: self.model.flow_rate(self.s, self.h, self.t, self.T, x)[0], self.erate
+            lambda x: self.model.flow_rate(self.s, self.h, self.t, self.T, x)[0],
+            self.erate,
         )
         self.assertTrue(np.allclose(exact, torch.flatten(numer), rtol=1.0e-4))
 
@@ -65,7 +72,8 @@ class CommonFlowRule:
 
         exact = self.model.dhist_derate(self.s, self.h, self.t, self.T, self.erate)
         numer = utility.new_differentiate(
-            lambda x: self.model.history_rate(self.s, self.h, self.t, self.T, x)[0], self.erate
+            lambda x: self.model.history_rate(self.s, self.h, self.t, self.T, x)[0],
+            self.erate,
         )[..., 0]
 
         self.assertTrue(np.allclose(exact, numer, rtol=1.0e-4))
@@ -85,7 +93,7 @@ class TestPerfectViscoplasticity(unittest.TestCase, CommonFlowRule):
         self.t = torch.ones(self.nbatch)
         self.skip = True
         self.T = torch.zeros_like(self.t)
-        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
+        self.erate = torch.linspace(1e-2, 1e-3, self.nbatch)
 
 
 class TestWrappedRIIsoKinViscoplasticity(unittest.TestCase, CommonFlowRule):
@@ -107,11 +115,12 @@ class TestWrappedRIIsoKinViscoplasticity(unittest.TestCase, CommonFlowRule):
         self.bmodel = flowrules.IsoKinViscoplasticity(
             CP(self.n), CP(self.eta), CP(self.s0), self.iso, self.kin
         )
-        
+
         self.l = 0.5
         self.eps_ref = 1e-4
-        self.model = flowrules.RateIndependentFlowRuleWrapper(self.bmodel,
-                self.l, self.eps_ref)
+        self.model = flowrules.RateIndependentFlowRuleWrapper(
+            self.bmodel, self.l, self.eps_ref
+        )
 
         self.s = torch.linspace(150, 200, self.nbatch)
         self.h = torch.reshape(
@@ -128,9 +137,10 @@ class TestWrappedRIIsoKinViscoplasticity(unittest.TestCase, CommonFlowRule):
 
         self.t = torch.ones(self.nbatch)
         self.T = torch.zeros_like(self.t)
-        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
+        self.erate = torch.linspace(1e-2, 1e-3, self.nbatch)
 
         self.skip = False
+
 
 class TestKocksMeckingRegimeFlowRule(unittest.TestCase, CommonFlowRule):
     def setUp(self):
@@ -151,7 +161,7 @@ class TestKocksMeckingRegimeFlowRule(unittest.TestCase, CommonFlowRule):
         self.model1 = flowrules.IsoKinViscoplasticity(
             CP(self.n1), CP(self.eta1), CP(self.s01), self.iso1, self.kin1
         )
-        
+
         self.n2 = torch.tensor(5.2)
         self.eta2 = torch.tensor(110.0)
         self.s02 = torch.tensor(11.0)
@@ -175,8 +185,9 @@ class TestKocksMeckingRegimeFlowRule(unittest.TestCase, CommonFlowRule):
 
         self.g0 = 1.5
 
-        self.model = flowrules.KocksMeckingRegimeFlowRule(self.model1, self.model2, 
-                self.g0, self.mu, self.b, self.eps0, self.k)
+        self.model = flowrules.KocksMeckingRegimeFlowRule(
+            self.model1, self.model2, self.g0, self.mu, self.b, self.eps0, self.k
+        )
 
         self.s = torch.linspace(150, 200, self.nbatch)
         self.h = torch.reshape(
@@ -193,9 +204,10 @@ class TestKocksMeckingRegimeFlowRule(unittest.TestCase, CommonFlowRule):
 
         self.t = torch.ones(self.nbatch)
         self.T = torch.ones_like(self.t) * 300
-        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
+        self.erate = torch.linspace(1e-2, 1e-3, self.nbatch)
 
         self.skip = False
+
 
 class TestIsoKinViscoplasticity(unittest.TestCase, CommonFlowRule):
     def setUp(self):
@@ -232,7 +244,7 @@ class TestIsoKinViscoplasticity(unittest.TestCase, CommonFlowRule):
 
         self.t = torch.ones(self.nbatch)
         self.T = torch.zeros_like(self.t)
-        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
+        self.erate = torch.linspace(1e-2, 1e-3, self.nbatch)
 
         self.skip = False
 
@@ -311,7 +323,7 @@ class TestSuperimposedFlowRate(unittest.TestCase, CommonFlowRule):
 
         self.t = torch.ones(self.nbatch)
         self.T = torch.zeros_like(self.t)
-        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
+        self.erate = torch.linspace(1e-2, 1e-3, self.nbatch)
 
         self.skip = False
 
@@ -352,7 +364,7 @@ class TestIsoKinChabocheViscoplasticity(unittest.TestCase, CommonFlowRule):
         )
         self.t = torch.ones(self.nbatch)
         self.T = torch.zeros_like(self.t)
-        self.erate = torch.linspace(1e-2,1e-3,self.nbatch)
+        self.erate = torch.linspace(1e-2, 1e-3, self.nbatch)
 
         self.skip = False
 

--- a/test/test_hardening.py
+++ b/test/test_hardening.py
@@ -19,10 +19,11 @@ class HardeningBase:
 
     def test_dstress(self):
         exact = self.model.dhistory_rate_dstress(
-            self.s, self.h, self.t, self.ep, self.T
+            self.s, self.h, self.t, self.ep, self.T, self.erate
         )
         numer = utility.new_differentiate(
-            lambda x: self.model.history_rate(x, self.h, self.t, self.ep, self.T),
+            lambda x: self.model.history_rate(x, self.h, self.t, self.ep, self.T,
+                self.erate),
             self.s,
         )
 
@@ -30,26 +31,37 @@ class HardeningBase:
 
     def test_dhistory(self):
         exact = self.model.dhistory_rate_dhistory(
-            self.s, self.h, self.t, self.ep, self.T
+            self.s, self.h, self.t, self.ep, self.T, self.erate
         )
         numer = utility.new_differentiate(
-            lambda x: self.model.history_rate(self.s, x, self.t, self.ep, self.T),
+            lambda x: self.model.history_rate(self.s, x, self.t, self.ep, self.T,
+                self.erate),
             self.h,
         )
-
-        print(exact.shape)
-        print(numer.shape)
 
         self.assertTrue(np.allclose(exact, numer, rtol=1.0e-3))
 
     def test_derate(self):
-        exact = self.model.dhistory_rate_derate(self.s, self.h, self.t, self.ep, self.T)
+        exact = self.model.dhistory_rate_derate(self.s, self.h, self.t, self.ep, self.T,
+                self.erate)
         numer = utility.new_differentiate(
-            lambda x: self.model.history_rate(self.s, self.h, self.t, x, self.T),
+            lambda x: self.model.history_rate(self.s, self.h, self.t, x, self.T,
+                self.erate),
             self.ep,
         )
 
         self.assertTrue(np.allclose(exact, numer, rtol=1.0e-4))
+
+    def test_dtotalrate(self):
+        exact = self.model.dhistory_rate_dtotalrate(self.s, self.h, self.t, self.ep, self.T,
+                self.erate)
+        numer = utility.new_differentiate(
+            lambda x: self.model.history_rate(self.s, self.h, self.t, self.ep, self.T,
+                x),
+            self.erate,
+        )
+
+        self.assertTrue(np.allclose(exact, numer[:,:,0], rtol=1.0e-4))
 
 
 class TestVoceIsotropicHardening(unittest.TestCase, HardeningBase):
@@ -65,6 +77,7 @@ class TestVoceIsotropicHardening(unittest.TestCase, HardeningBase):
         self.t = torch.ones(self.nbatch)
         self.ep = torch.linspace(0.1, 0.2, self.nbatch)
         self.T = torch.zeros_like(self.t)
+        self.erate = torch.linspace(0.01, 0.02, self.nbatch)
 
 
 class TestVoceIsotropicThetaHardening(unittest.TestCase, HardeningBase):
@@ -82,6 +95,7 @@ class TestVoceIsotropicThetaHardening(unittest.TestCase, HardeningBase):
         self.t = torch.ones(self.nbatch)
         self.ep = torch.linspace(0.1, 0.2, self.nbatch)
         self.T = torch.zeros_like(self.t)
+        self.erate = torch.linspace(0.01, 0.02, self.nbatch)
 
 
 class TestVoceIsotropicThetaReceoveryHardening(unittest.TestCase, HardeningBase):
@@ -102,6 +116,7 @@ class TestVoceIsotropicThetaReceoveryHardening(unittest.TestCase, HardeningBase)
         self.t = torch.ones(self.nbatch)
         self.ep = torch.linspace(0.1, 0.2, self.nbatch)
         self.T = torch.zeros_like(self.t)
+        self.erate = torch.linspace(0.01, 0.02, self.nbatch)
 
 
 class TestFAKinematicHardening(unittest.TestCase, HardeningBase):
@@ -117,6 +132,7 @@ class TestFAKinematicHardening(unittest.TestCase, HardeningBase):
         self.t = torch.ones(self.nbatch)
         self.ep = torch.linspace(0.1, 0.2, self.nbatch)
         self.T = torch.zeros_like(self.t)
+        self.erate = torch.linspace(0.01, 0.02, self.nbatch)
 
 
 class TestFAKinematicHardeningRecovery(unittest.TestCase, HardeningBase):
@@ -136,6 +152,7 @@ class TestFAKinematicHardeningRecovery(unittest.TestCase, HardeningBase):
         self.t = torch.ones(self.nbatch)
         self.ep = torch.linspace(0.1, 0.2, self.nbatch)
         self.T = torch.zeros_like(self.t)
+        self.erate = torch.linspace(0.01, 0.02, self.nbatch)
 
 
 class TestSuperimposedKinematicHardening(unittest.TestCase, HardeningBase):
@@ -161,6 +178,7 @@ class TestSuperimposedKinematicHardening(unittest.TestCase, HardeningBase):
         self.t = torch.ones(self.nbatch)
         self.ep = torch.linspace(0.1, 0.2, self.nbatch)
         self.T = torch.zeros_like(self.t)
+        self.erate = torch.linspace(0.01, 0.02, self.nbatch)
 
     def test_correct_sum(self):
         should = torch.sum(self.h, 1)
@@ -169,12 +187,13 @@ class TestSuperimposedKinematicHardening(unittest.TestCase, HardeningBase):
         self.assertTrue(np.allclose(should.numpy(), model.numpy()))
 
     def test_correct_rate(self):
-        rates = self.model.history_rate(self.s, self.h, self.t, self.ep, self.T)
+        rates = self.model.history_rate(self.s, self.h, self.t, self.ep, self.T,
+                self.erate)
 
         self.assertTrue(
             np.allclose(
                 self.model1.history_rate(
-                    self.s, self.h[:, :1], self.t, self.ep, self.T
+                    self.s, self.h[:, :1], self.t, self.ep, self.T, self.erate
                 ),
                 rates[:, :1],
             )
@@ -182,7 +201,7 @@ class TestSuperimposedKinematicHardening(unittest.TestCase, HardeningBase):
         self.assertTrue(
             np.allclose(
                 self.model2.history_rate(
-                    self.s, self.h[:, 1:2], self.t, self.ep, self.T
+                    self.s, self.h[:, 1:2], self.t, self.ep, self.T, self.erate
                 ),
                 rates[:, 1:2],
             )
@@ -205,6 +224,7 @@ class TestChabocheKinematicHardening(unittest.TestCase, HardeningBase):
         self.t = torch.ones(self.nbatch)
         self.ep = torch.linspace(0.1, 0.2, self.nbatch)
         self.T = torch.zeros_like(self.t)
+        self.erate = torch.linspace(0.01, 0.02, self.nbatch)
 
 
 class TestChabocheKinematicHardeningRecovery(unittest.TestCase, HardeningBase):
@@ -227,3 +247,4 @@ class TestChabocheKinematicHardeningRecovery(unittest.TestCase, HardeningBase):
         self.t = torch.ones(self.nbatch)
         self.ep = torch.linspace(0.1, 0.2, self.nbatch)
         self.T = torch.zeros_like(self.t)
+        self.erate = torch.linspace(0.01, 0.02, self.nbatch)

--- a/test/test_hardening.py
+++ b/test/test_hardening.py
@@ -22,8 +22,9 @@ class HardeningBase:
             self.s, self.h, self.t, self.ep, self.T, self.erate
         )
         numer = utility.new_differentiate(
-            lambda x: self.model.history_rate(x, self.h, self.t, self.ep, self.T,
-                self.erate),
+            lambda x: self.model.history_rate(
+                x, self.h, self.t, self.ep, self.T, self.erate
+            ),
             self.s,
         )
 
@@ -34,34 +35,39 @@ class HardeningBase:
             self.s, self.h, self.t, self.ep, self.T, self.erate
         )
         numer = utility.new_differentiate(
-            lambda x: self.model.history_rate(self.s, x, self.t, self.ep, self.T,
-                self.erate),
+            lambda x: self.model.history_rate(
+                self.s, x, self.t, self.ep, self.T, self.erate
+            ),
             self.h,
         )
 
         self.assertTrue(np.allclose(exact, numer, rtol=1.0e-3))
 
     def test_derate(self):
-        exact = self.model.dhistory_rate_derate(self.s, self.h, self.t, self.ep, self.T,
-                self.erate)
+        exact = self.model.dhistory_rate_derate(
+            self.s, self.h, self.t, self.ep, self.T, self.erate
+        )
         numer = utility.new_differentiate(
-            lambda x: self.model.history_rate(self.s, self.h, self.t, x, self.T,
-                self.erate),
+            lambda x: self.model.history_rate(
+                self.s, self.h, self.t, x, self.T, self.erate
+            ),
             self.ep,
         )
 
         self.assertTrue(np.allclose(exact, numer, rtol=1.0e-4))
 
     def test_dtotalrate(self):
-        exact = self.model.dhistory_rate_dtotalrate(self.s, self.h, self.t, self.ep, self.T,
-                self.erate)
+        exact = self.model.dhistory_rate_dtotalrate(
+            self.s, self.h, self.t, self.ep, self.T, self.erate
+        )
         numer = utility.new_differentiate(
-            lambda x: self.model.history_rate(self.s, self.h, self.t, self.ep, self.T,
-                x),
+            lambda x: self.model.history_rate(
+                self.s, self.h, self.t, self.ep, self.T, x
+            ),
             self.erate,
         )
 
-        self.assertTrue(np.allclose(exact, numer[:,:,0], rtol=1.0e-4))
+        self.assertTrue(np.allclose(exact, numer[:, :, 0], rtol=1.0e-4))
 
 
 class TestVoceIsotropicHardening(unittest.TestCase, HardeningBase):
@@ -187,8 +193,9 @@ class TestSuperimposedKinematicHardening(unittest.TestCase, HardeningBase):
         self.assertTrue(np.allclose(should.numpy(), model.numpy()))
 
     def test_correct_rate(self):
-        rates = self.model.history_rate(self.s, self.h, self.t, self.ep, self.T,
-                self.erate)
+        rates = self.model.history_rate(
+            self.s, self.h, self.t, self.ep, self.T, self.erate
+        )
 
         self.assertTrue(
             np.allclose(


### PR DESCRIPTION
This PR:
- Uses Walker's method to "wrap" a rate dependent model and make it approximately rate independent.
- Adds a Kocks-Mecking rate sensitivity switching model.

All of this should be compatible with the entire pytorch/pyro stack for inference.